### PR TITLE
ClearChat packet

### DIFF
--- a/MtaServer.Console/Program.cs
+++ b/MtaServer.Console/Program.cs
@@ -119,6 +119,8 @@ namespace MtaServer.Console
                 ));
                 client.SendPacket(new FadeCameraPacket(CameraFade.In));
                 client.SendPacket(new ChatEchoPacket(server.Root.Id, "Hello World", Color.White));
+                client.SendPacket(new ClearChatPacket());
+                client.SendPacket(new ChatEchoPacket(server.Root.Id, "Hello World Again", Color.White));
 
                 TestPureSync(client);
             };

--- a/MtaServer.Net/NetWrapper.cs
+++ b/MtaServer.Net/NetWrapper.cs
@@ -65,7 +65,7 @@ namespace MTAServerWrapper.Server
 
         void SendPacket(uint binaryAddress, byte packetId, byte[] payload)
         {
-            int size = Marshal.SizeOf(payload[0]) * payload.Length;
+            int size = Marshal.SizeOf((byte)0) * payload.Length;
             IntPtr pointer = Marshal.AllocHGlobal(size);
             try
             {

--- a/MtaServer.Packets/Definitions/Player/ClearChatPacket.cs
+++ b/MtaServer.Packets/Definitions/Player/ClearChatPacket.cs
@@ -1,0 +1,29 @@
+﻿using MtaServer.Packets.Enums;
+using System;
+using System.Drawing;
+using System.Linq;
+
+namespace MtaServer.Packets.Definitions.Player
+{
+    public class ClearChatPacket : Packet
+    {
+        public override PacketId PacketId => PacketId.PACKET_ID_CHAT_CLEAR;
+        public override PacketFlags Flags => PacketFlags.PACKET_MEDIUM_PRIORITY;
+
+        public ClearChatPacket()
+        {
+
+        }
+
+        public override void Read(byte[] bytes)
+        {
+        }
+
+        public override byte[] Write()
+        {
+            var builder = new PacketBuilder();
+            builder.Write(false);
+            return builder.Build();
+        }
+    }
+}

--- a/MtaServer.Packets/Definitions/Player/ClearChatPacket.cs
+++ b/MtaServer.Packets/Definitions/Player/ClearChatPacket.cs
@@ -19,10 +19,6 @@ namespace MtaServer.Packets.Definitions.Player
         {
         }
 
-        public override byte[] Write()
-        {
-            var builder = new PacketBuilder();
-            return builder.Build();
-        }
+        public override byte[] Write() => new byte[0];
     }
 }

--- a/MtaServer.Packets/Definitions/Player/ClearChatPacket.cs
+++ b/MtaServer.Packets/Definitions/Player/ClearChatPacket.cs
@@ -22,7 +22,6 @@ namespace MtaServer.Packets.Definitions.Player
         public override byte[] Write()
         {
             var builder = new PacketBuilder();
-            builder.Write(false);
             return builder.Build();
         }
     }


### PR DESCRIPTION
https://wiki.multitheftauto.com/wiki/ClearChatBox

even packet don't need any write, i added unused `builder.Write(false);` due crash it cause otherwise
![image](https://user-images.githubusercontent.com/22455534/86020816-aea92400-ba28-11ea-8a1e-f0dafc81cb4c.png)
