### PR TITLE
Fixes for pure sync and player quitting

### DIFF
--- a/SlipeServer.Console/Resources/TestResource/test.lua
+++ b/SlipeServer.Console/Resources/TestResource/test.lua
@@ -15,3 +15,9 @@ addEventHandler("Slipe.Test.ClientEvent", root, function(...)
 end)
 
 outputChatBox("Event ready");
+
+addCommandHandler("crun", function(command, ...)
+	outputChatBox("Running code")
+	local code = table.concat({ ... }, " ")
+	loadstring(code)()
+end)

--- a/SlipeServer.Console/ServerTestLogic.cs
+++ b/SlipeServer.Console/ServerTestLogic.cs
@@ -126,7 +126,6 @@ namespace SlipeServer.Console
         {
             var client = player.Client;
 
-            this.logger.LogInformation($"{player.Name} ({client.Version}) ({client.Serial}) has joined the server!");
             this.chatBox.Output($"{player.Name} ({client.Version}) ({client.Serial}) has joined the server!");
 
             player.Spawn(new Vector3(0, 0, 3), 0, 7, 0, 0);
@@ -193,7 +192,7 @@ namespace SlipeServer.Console
             player.Weapons.Add(new Weapon(WeaponId.Tec9, 500));
             player.Weapons.Add(new Weapon(WeaponId.Sniper, 500));
             player.Weapons.Add(new Weapon(WeaponId.Deagle, 500));
-            player.Weapons.Add(new Weapon(WeaponId.Golfclub, 500));
+            player.Weapons.Add(new Weapon(WeaponId.Golfclub, 1));
             player.Weapons.Remove(WeaponId.Tec9);
             player.Weapons.Remove(WeaponId.Sniper);
             player.Weapons.First(weapon => weapon.Type == WeaponId.Deagle).Ammo -= 200;

--- a/SlipeServer.Packets/Definitions/Join/PlayerListPacket.cs
+++ b/SlipeServer.Packets/Definitions/Join/PlayerListPacket.cs
@@ -131,7 +131,7 @@ namespace SlipeServer.Packets.Definitions.Join
                 } else
                 {
                     builder.Write(true);
-                    builder.Write(weapons[i]);
+                    builder.WriteCapped(weapons[i], 6);
                 }
             }
         }

--- a/SlipeServer.Packets/Definitions/Sync/PlayerPureSyncPacket.cs
+++ b/SlipeServer.Packets/Definitions/Sync/PlayerPureSyncPacket.cs
@@ -3,9 +3,6 @@ using SlipeServer.Packets.Structures;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using SlipeServer.Packets.Builder;
 using SlipeServer.Packets.Reader;
 
@@ -147,15 +144,13 @@ namespace SlipeServer.Packets.Definitions.Sync
 
             if (this.SyncFlags.HasAWeapon)
             {
-                builder.Write(this.WeaponType);
                 builder.WriteCapped(this.WeaponSlot, 4);
 
                 if (slotsWithAmmo.Contains(this.WeaponSlot))
                 {
-                    builder.WriteAmmo(this.TotalAmmo, this.AmmoInClip);
+                    builder.WriteAmmo(null, this.AmmoInClip);
 
-                    builder.Write(this.Arm * 90 * 180 * MathF.PI);
-                    //this.Arm = ((reader.GetUint16()) * MathF.PI / 180) / 90.0f;
+                    builder.Write((short)(this.Arm * 90 * 180 / MathF.PI));
 
                     // if player is aiming
                     if (this.KeySync.RightShoulder1 || this.KeySync.ButtonCircle)

--- a/SlipeServer.Server/Behaviour/PlayerJoinElementBehaviour.cs
+++ b/SlipeServer.Server/Behaviour/PlayerJoinElementBehaviour.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Logging;
+using MTAServerWrapper.Packets.Outgoing.Connection;
 using SlipeServer.Server.Elements;
+using SlipeServer.Server.Extensions;
 using SlipeServer.Server.PacketHandling.Factories;
 using SlipeServer.Server.Repositories;
 
@@ -14,11 +18,12 @@ namespace SlipeServer.Server.Behaviour
     public class PlayerJoinElementBehaviour
     {
         private readonly IElementRepository elementRepository;
+        private readonly ILogger logger;
 
-        public PlayerJoinElementBehaviour(IElementRepository elementRepository, MtaServer server)
+        public PlayerJoinElementBehaviour(IElementRepository elementRepository, MtaServer server, ILogger logger)
         {
             this.elementRepository = elementRepository;
-
+            this.logger = logger;
             server.PlayerJoined += OnPlayerJoin;
         }
 
@@ -27,6 +32,23 @@ namespace SlipeServer.Server.Behaviour
             var elements = this.elementRepository.GetAll();
             var packet = AddEntityPacketFactory.CreateAddEntityPacket(elements);
             player.Client.SendPacket(packet);
+
+            player.Disconnected += OnPlayerDisconnect;
+
+            this.logger.LogInformation($"{player.Name} ({player.Client.Version}) ({player.Client.Serial}) has joined the server!");
+        }
+
+        private void OnPlayerDisconnect(object? sender, Elements.Events.PlayerQuitEventArgs e)
+        {
+            var player = sender as Player;
+            this.logger.LogInformation($"{player!.Name} ({player.Client.Version}) ({player.Client.Serial}) has left the server!");
+
+            var packet = new PlayerQuitPacket(player.Id, (byte)e.Reason);
+
+            var otherPlayers = this.elementRepository
+                .GetByType<Player>(ElementType.Player)
+                .Where(p => p != player);
+            packet.SendTo(otherPlayers);
         }
     }
 }

--- a/SlipeServer.Server/Configuration.cs
+++ b/SlipeServer.Server/Configuration.cs
@@ -21,7 +21,7 @@ namespace SlipeServer.Server
         public string Password { get; set; } = "";
 
 
-        public string HttpHost { get; set; } = "127.0.0.1";
+        public string HttpHost { get; set; } = "*";
 
         public ushort HttpPort { get; set; } = 40680;
 

--- a/SlipeServer.Server/Elements/Events/PlayerQuitEventArgs.cs
+++ b/SlipeServer.Server/Elements/Events/PlayerQuitEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using SlipeServer.Server.Enums;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SlipeServer.Server.Elements.Events
+{
+    public class PlayerQuitEventArgs : EventArgs
+    {
+        public QuitReason Reason { get; }
+
+        public PlayerQuitEventArgs(QuitReason reason)
+        {
+            Reason = reason;
+        }
+    }
+}

--- a/SlipeServer.Server/Elements/Player.cs
+++ b/SlipeServer.Server/Elements/Player.cs
@@ -118,10 +118,17 @@ namespace SlipeServer.Server.Elements
             this.Kill(null, damageType, bodyPart);
         }
 
+        public void TriggerDisconnected(QuitReason reason)
+        {
+            this.Disconnected?.Invoke(this, new PlayerQuitEventArgs(reason));
+            this.Destroy();
+        }
+
         public event ElementChangedEventHandler<Player, byte>? WantedLevelChanged;
         public event EventHandler<PlayerDamagedEventArgs>? Damaged;
         public event EventHandler<PlayerWastedEventArgs>? Wasted;
         public event EventHandler<PlayerSpawnedEventArgs>? Spawned;
         public event EventHandler<PlayerCommandEventArgs>? OnCommand;
+        public event EventHandler<PlayerQuitEventArgs>? Disconnected;
     }
 }

--- a/SlipeServer.Server/PacketHandling/Factories/PlayerPacketFactory.cs
+++ b/SlipeServer.Server/PacketHandling/Factories/PlayerPacketFactory.cs
@@ -11,6 +11,7 @@ using System.Drawing;
 using System.Numerics;
 using System.Text;
 using SlipeServer.Packets.Definitions.Player;
+using System.Linq;
 
 namespace SlipeServer.Server.PacketHandling.Factories
 {
@@ -34,33 +35,36 @@ namespace SlipeServer.Server.PacketHandling.Factories
                     bitsreamVersion: 343,
                     buildNumber: 0,
 
-                    isDead: false,
-                    isInVehicle: false,
+                    isDead: !player.IsAlive,
+                    isInVehicle: player.Vehicle != null,
                     hasJetpack: false,
                     isNametagShowing: true,
                     isNametagColorOverriden: true,
-                    isHeadless: false,
-                    isFrozen: false,
+                    isHeadless: player.IsHeadless,
+                    isFrozen: player.IsFrozen,
 
                     nametagText: player.Name ?? "???",
                     color: Color.FromArgb(255, 255, 0, 255),
                     moveAnimation: 0,
 
-                    model: 9,
+                    model: player.Model,
                     teamId: null,
 
-                    vehicleId: null,
-                    seat: null,
+                    vehicleId: player.Vehicle?.Id,
+                    seat: player.Seat,
 
                     position: player.Position,
                     rotation: player.PedRotation,
 
-                    dimension: 0,
+                    dimension: player.Dimension,
                     fightingStyle: 0,
-                    alpha: 255,
-                    interior: 0,
+                    alpha: player.Alpha,
+                    interior: player.Interior,
 
-                    weapons: new byte[16]
+                    weapons: (new byte[16]).Select((value, index) =>
+                    {
+                        return (byte)(player.Weapons.Get((WeaponSlot)index)?.Type ?? 0);
+                    }).ToArray()
                 );
             }
 


### PR DESCRIPTION
- Player list packet includes more fields
- Sync properly sends aim direction
- Player quit now triggers event
- Player element is destroyed on quit
- Player element is removed from repository on quit
- Player disconnect packet is sent to other clients
