### PR TITLE
Lua userdata

### DIFF
--- a/SlipeServer.Console/LuaDefinitions/TestDefinition.cs
+++ b/SlipeServer.Console/LuaDefinitions/TestDefinition.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
+using SlipeServer.Console.LuaDefinitions.Userdatas;
+using SlipeServer.Lua;
 using SlipeServer.Scripting;
 using SlipeServer.Server.Services;
 
@@ -18,6 +20,22 @@ namespace SlipeServer.Console.LuaDefinitions
         {
             this.logger.LogInformation($"{a} == {b} : {a.Equals(b)}");
             return a.Equals(b);
+        }
+
+        [ScriptFunctionDefinition("createFoo")]
+        public FooUserdata CreateFoo(int a, int b)
+        {
+            return new FooUserdata
+            {
+                A = a,
+                B = b,
+            };
+        }
+
+        [ScriptFunctionDefinition("sumFoo")]
+        public int SumFoo(FooUserdata foo)
+        {
+            return foo.A + foo.B;
         }
     }
 }

--- a/SlipeServer.Console/LuaDefinitions/Userdatas/FooUserdata.cs
+++ b/SlipeServer.Console/LuaDefinitions/Userdatas/FooUserdata.cs
@@ -1,0 +1,15 @@
+﻿using SlipeServer.Lua;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlipeServer.Console.LuaDefinitions.Userdatas
+{
+    public class FooUserdata : IUserdata
+    {
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+}

--- a/SlipeServer.Console/test.lua
+++ b/SlipeServer.Console/test.lua
@@ -54,3 +54,6 @@ print("check radarArea: ",
 	insideD == true and insideE == false and insideF == false,
 	flashing == false
 )
+
+local foo = createFoo(49,51);
+print("custom userdata:", foo, sumFoo(foo), sumFoo(foo) == 100);

--- a/SlipeServer.Lua/IUserdata.cs
+++ b/SlipeServer.Lua/IUserdata.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlipeServer.Lua
+{
+    public interface IUserdata
+    {
+    }
+}

--- a/SlipeServer.Lua/LuaTranslator.cs
+++ b/SlipeServer.Lua/LuaTranslator.cs
@@ -15,6 +15,7 @@ namespace SlipeServer.Lua
         public LuaTranslator()
         {
             UserData.RegisterType<Element>(InteropAccessMode.Hardwired);
+            UserData.RegisterType<IUserdata>(InteropAccessMode.Hardwired);
         }
 
         public IEnumerable<DynValue> ToDynValues(object? obj)
@@ -23,6 +24,8 @@ namespace SlipeServer.Lua
                 return new DynValue[] { DynValue.Nil };
             if (obj is Element element)
                 return new DynValue[] { UserData.Create(element) };
+            if (obj is IUserdata userdata)
+                return new DynValue[] { UserData.Create(userdata) };
             if (obj is byte int8)
                 return new DynValue[] { DynValue.NewNumber(int8) };
             if (obj is short int16)
@@ -131,6 +134,8 @@ namespace SlipeServer.Lua
             if (targetType == typeof(Table))
                 return GetTableFromDynValue(dynValues.Dequeue());
             if (typeof(Element).IsAssignableFrom(targetType))
+                return dynValues.Dequeue().UserData.Object;
+            if (typeof(IUserdata).IsAssignableFrom(targetType))
                 return dynValues.Dequeue().UserData.Object;
             if (targetType == typeof(ScriptCallbackDelegateWrapper))
             {


### PR DESCRIPTION
The goal of this pr is to let people use their custom, non-element classes into lua.
If class inherits from `IUserdata`, it can be moved in and out of lua.