### PR TITLE
Fix multiple resources don't work

### DIFF
--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -343,7 +343,7 @@ namespace SlipeServer.Console.Logic
             player.Weapons.First(weapon => weapon.Type == WeaponId.Ak47).AmmoInClip = 25;
 
             this.testResource?.StartFor(player);
-            //this.secondTestResource?.StartFor(player);
+            this.secondTestResource?.StartFor(player);
 
             this.HandlePlayerSubscriptions(player);
             this.HandlePlayerCommands(player);

--- a/SlipeServer.Server/Resources/Resource.cs
+++ b/SlipeServer.Server/Resources/Resource.cs
@@ -23,6 +23,7 @@ namespace SlipeServer.Server.Resources
 
         public Resource(MtaServer server, RootElement root, IResourceServer resourceServer, string name, string? path = null)
         {
+            this.NetId = resourceServer.AllocateNetId();
             this.server = server;
             this.resourceServer = resourceServer;
             this.Name = name;

--- a/SlipeServer.Server/Resources/ResourceServing/BasicHttpServer.cs
+++ b/SlipeServer.Server/Resources/ResourceServing/BasicHttpServer.cs
@@ -22,6 +22,7 @@ namespace SlipeServer.Server.Resources.ResourceServing
         private readonly ILogger logger;
         private readonly string httpAddress;
         private bool isRunning;
+        private HashSet<ushort> usedNetIds;
 
         public BasicHttpServer(Configuration configuration, ILogger logger)
         {
@@ -33,6 +34,7 @@ namespace SlipeServer.Server.Resources.ResourceServing
             this.rootDirectory = configuration.ResourceDirectory;
             this.configuration = configuration;
             this.logger = logger;
+            this.usedNetIds = new();
         }
 
         public void Start()
@@ -92,6 +94,20 @@ namespace SlipeServer.Server.Resources.ResourceServing
         public void Stop()
         {
             this.isRunning = false;
+        }
+
+        public ushort AllocateNetId()
+        {
+            ushort id = 0;
+            while (this.usedNetIds.Contains(id))
+                id++;
+            this.usedNetIds.Add(id);
+            return id;
+        }
+
+        public void ReleaseNetId(ushort id)
+        {
+            this.usedNetIds.Remove(id);
         }
 
         public IEnumerable<ResourceFile> GetResourceFiles(string resource)

--- a/SlipeServer.Server/Resources/ResourceServing/IResourceServer.cs
+++ b/SlipeServer.Server/Resources/ResourceServing/IResourceServer.cs
@@ -12,6 +12,8 @@ namespace SlipeServer.Server.Resources.ResourceServing
     {
         void Start();
         void Stop();
+        ushort AllocateNetId();
+        void ReleaseNetId(ushort netId);
 
         IEnumerable<ResourceFile> GetResourceFiles();
         IEnumerable<ResourceFile> GetResourceFiles(string resource);


### PR DESCRIPTION
Fixes multiple resources crash caused by duplicated NetId clientside. Now `IResourceServer` has two method to allocate and release net ids, this methods right now has linear complexity. People don't often create/remove resources so it doesn't matter right now.