### PR TITLE
World service, water color, level, waves

### DIFF
--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -590,6 +590,12 @@ namespace SlipeServer.Console.Logic
                         }
                     }
                 }
+
+                if (args.Command == "watercolor")
+                {
+                    this.worldService.SetWaterColor(Color.FromArgb(random.Next(255), random.Next(255), random.Next(255)));
+                    this.chatBox.OutputTo(player, "You have randomized water color!", Color.YellowGreen);
+                }
             };
 
             player.AcInfoReceived += (o, args) =>

--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -596,6 +596,11 @@ namespace SlipeServer.Console.Logic
                     this.worldService.SetWaterColor(Color.FromArgb(random.Next(255), random.Next(255), random.Next(255)));
                     this.chatBox.OutputTo(player, "You have randomized water color!", Color.YellowGreen);
                 }
+                if (args.Command == "flood")
+                {
+                    this.worldService.SetWaterLevel(5);
+                    this.chatBox.OutputTo(player, "You have flooded the map!", Color.YellowGreen);
+                }
             };
 
             player.AcInfoReceived += (o, args) =>

--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -601,6 +601,17 @@ namespace SlipeServer.Console.Logic
                     this.worldService.SetWaterLevel(5);
                     this.chatBox.OutputTo(player, "You have flooded the map!", Color.YellowGreen);
                 }
+                if (args.Command == "wave")
+                {
+                    if (args.Arguments.Length > 0)
+                    {
+                        if (float.TryParse(args.Arguments[0], out float waveHeight))
+                        {
+                            this.worldService.SetWaveHeight(waveHeight);
+                            this.chatBox.OutputTo(player, $"Wave height changed to {waveHeight}.", Color.YellowGreen);
+                        }
+                    }
+                }
             };
 
             player.AcInfoReceived += (o, args) =>

--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -596,10 +596,16 @@ namespace SlipeServer.Console.Logic
                     this.worldService.SetWaterColor(Color.FromArgb(random.Next(255), random.Next(255), random.Next(255)));
                     this.chatBox.OutputTo(player, "You have randomized water color!", Color.YellowGreen);
                 }
-                if (args.Command == "flood")
+                if (args.Command == "waterlevel")
                 {
-                    this.worldService.SetWaterLevel(5);
-                    this.chatBox.OutputTo(player, "You have flooded the map!", Color.YellowGreen);
+                    if (args.Arguments.Length > 0)
+                    {
+                        if (float.TryParse(args.Arguments[0], out float waveHeight))
+                        {
+                            this.worldService.SetWaterLevel(waveHeight);
+                            this.chatBox.OutputTo(player, $"Water level changed to {waveHeight}.", Color.YellowGreen);
+                        }
+                    }
                 }
                 if (args.Command == "wave")
                 {

--- a/SlipeServer.Packets/Definitions/Lua/Rpc/World/SetWaterColorPacket.cs
+++ b/SlipeServer.Packets/Definitions/Lua/Rpc/World/SetWaterColorPacket.cs
@@ -1,0 +1,40 @@
+﻿using SlipeServer.Packets.Builder;
+using SlipeServer.Packets.Enums;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlipeServer.Packets.Definitions.Lua.Rpc.World
+{
+    public class SetWaterColorPacket : Packet
+    {
+        public override PacketId PacketId => PacketId.PACKET_ID_LUA;
+        public override PacketReliability Reliability => PacketReliability.ReliableSequenced;
+        public override PacketPriority Priority => PacketPriority.High;
+
+        public Color Color { get; set; }
+        public bool Forced { get; set; }
+
+        public SetWaterColorPacket(Color color)
+        {
+            this.Color = color;
+        }
+
+        public override void Read(byte[] bytes)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override byte[] Write()
+        {
+            PacketBuilder builder = new PacketBuilder();
+            builder.Write((byte)ElementRPCFunction.SET_WATER_COLOR);
+            builder.Write(this.Color, true);
+
+            return builder.Build();
+        }
+    }
+}

--- a/SlipeServer.Packets/Definitions/Lua/Rpc/World/SetWaterLevelPacket.cs
+++ b/SlipeServer.Packets/Definitions/Lua/Rpc/World/SetWaterLevelPacket.cs
@@ -1,0 +1,48 @@
+﻿using SlipeServer.Packets.Builder;
+using SlipeServer.Packets.Enums;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlipeServer.Packets.Definitions.Lua.Rpc.World
+{
+    public class SetWaterLevelPacket : Packet
+    {
+        public override PacketId PacketId => PacketId.PACKET_ID_LUA;
+        public override PacketReliability Reliability => PacketReliability.ReliableSequenced;
+        public override PacketPriority Priority => PacketPriority.High;
+
+        public float Level { get; set; }
+        public bool IncludeWaterFeatures { get; set; }
+        public bool IncludeWorldSea { get; set; }
+        public bool IncludeOutsideWorldSea { get; set; }
+
+        public SetWaterLevelPacket(float level, bool includeWaterFeatures = true, bool includeWorldSea = true, bool includeOutsideWorldSea = false)
+        {
+            this.Level = level;
+            this.IncludeWaterFeatures = includeWaterFeatures;
+            this.IncludeWorldSea = includeWorldSea;
+            this.IncludeOutsideWorldSea = includeOutsideWorldSea;
+        }
+
+        public override void Read(byte[] bytes)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override byte[] Write()
+        {
+            PacketBuilder builder = new PacketBuilder();
+            builder.Write((byte)ElementRPCFunction.SET_WORLD_WATER_LEVEL);
+            builder.Write(this.Level);
+            builder.Write(this.IncludeWaterFeatures);
+            builder.Write(this.IncludeWorldSea);
+            builder.Write(this.IncludeOutsideWorldSea);
+
+            return builder.Build();
+        }
+    }
+}

--- a/SlipeServer.Packets/Definitions/Lua/Rpc/World/SetWaveHeightPacket.cs
+++ b/SlipeServer.Packets/Definitions/Lua/Rpc/World/SetWaveHeightPacket.cs
@@ -1,0 +1,39 @@
+﻿using SlipeServer.Packets.Builder;
+using SlipeServer.Packets.Enums;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlipeServer.Packets.Definitions.Lua.Rpc.World
+{
+    public class SetWaveHeightPacket : Packet
+    {
+        public override PacketId PacketId => PacketId.PACKET_ID_LUA;
+        public override PacketReliability Reliability => PacketReliability.ReliableSequenced;
+        public override PacketPriority Priority => PacketPriority.High;
+
+        public float Level { get; set; }
+
+        public SetWaveHeightPacket(float level)
+        {
+            this.Level = level;
+        }
+
+        public override void Read(byte[] bytes)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override byte[] Write()
+        {
+            PacketBuilder builder = new PacketBuilder();
+            builder.Write((byte)ElementRPCFunction.SET_WAVE_HEIGHT);
+            builder.Write(this.Level);
+
+            return builder.Build();
+        }
+    }
+}

--- a/SlipeServer.Server/Services/GameWorld.cs
+++ b/SlipeServer.Server/Services/GameWorld.cs
@@ -27,6 +27,9 @@ namespace SlipeServer.Server.Services
 
         private Color? waterColor;
         private float waterLevel;
+        private bool includeWaterFeatures = true;
+        private bool includeWorldSea = true;
+        private bool includeOutsideWorldSea = false;
         private float waveHeight;
 
         private TrafficLightState trafficLightState;
@@ -304,7 +307,10 @@ namespace SlipeServer.Server.Services
             if(this.waterColor != null)
                 player.Client.SendPacket(new SetWaterColorPacket(this.waterColor.Value));
 
-            if(this.waveHeight != 0)
+            if(this.waterLevel != 0)
+                this.server.BroadcastPacket(new SetWaterLevelPacket(this.waterLevel, this.includeWaterFeatures, this.includeWorldSea, this.includeOutsideWorldSea));
+
+            if (this.waveHeight != 0)
                 this.server.BroadcastPacket(new SetWaveHeightPacket(this.waveHeight));
         }
 
@@ -392,8 +398,11 @@ namespace SlipeServer.Server.Services
         public void SetWaterLevel(float waterLevel, bool includeWaterFeatures = true, bool includeWorldSea = true, bool includeOutsideWorldSea = false)
         {
             this.waterLevel = waterLevel;
+            this.includeWaterFeatures = includeWaterFeatures;
+            this.includeWorldSea = includeWorldSea;
+            this.includeOutsideWorldSea = includeOutsideWorldSea;
 
-            this.server.BroadcastPacket(new SetWaterLevelPacket(waterLevel, includeWaterFeatures, includeWorldSea, includeOutsideWorldSea));
+            this.server.BroadcastPacket(new SetWaterLevelPacket(this.waterLevel, this.includeWaterFeatures, this.includeWorldSea, this.includeOutsideWorldSea));
         }
 
         public void SetWaveHeight(float waveHeight)

--- a/SlipeServer.Server/Services/GameWorld.cs
+++ b/SlipeServer.Server/Services/GameWorld.cs
@@ -1,4 +1,4 @@
-﻿using SlipeServer.Packets.Definitions.Lua.Rpc.World;
+using SlipeServer.Packets.Definitions.Lua.Rpc.World;
 using SlipeServer.Packets.Definitions.Sync;
 using SlipeServer.Server.Elements;
 using SlipeServer.Server.Enums;
@@ -24,6 +24,8 @@ namespace SlipeServer.Server.Services
 
         private Color? sunCoreColor;
         private Color? sunCoronaColor;
+
+        private Color? waterColor;
 
         private TrafficLightState trafficLightState;
         private bool trafficLightStateForced;
@@ -296,6 +298,9 @@ namespace SlipeServer.Server.Services
             player.Client.SendPacket(new SetWindVelocityPacket(this.windVelocity));
             foreach (var item in enabledGlitches)
                 player.Client.SendPacket(new SetGlitchEnabledPacket((byte)item.Key, item.Value));
+
+            if(this.waterColor != null)
+                player.Client.SendPacket(new SetWaterColorPacket(this.waterColor.Value));
         }
 
         public void SetWeather(byte weather)
@@ -366,6 +371,18 @@ namespace SlipeServer.Server.Services
             return (this.sunCoreColor != null && this.sunCoronaColor != null) ?
                 new Tuple<Color, Color>(this.sunCoreColor.Value, this.sunCoronaColor.Value) :
                 null;
+        }
+        
+        public void SetWaterColor(Color color)
+        {
+            this.waterColor = color;
+
+            this.server.BroadcastPacket(new SetWaterColorPacket(color));
+        }
+
+        public Color? GetWaterColor()
+        {
+            return this.waterColor;
         }
 
         public void SetTrafficLightState(TrafficLightState state, bool forced = false)

--- a/SlipeServer.Server/Services/GameWorld.cs
+++ b/SlipeServer.Server/Services/GameWorld.cs
@@ -27,6 +27,7 @@ namespace SlipeServer.Server.Services
 
         private Color? waterColor;
         private float waterLevel;
+        private float waveHeight;
 
         private TrafficLightState trafficLightState;
         private bool trafficLightStateForced;
@@ -302,6 +303,9 @@ namespace SlipeServer.Server.Services
 
             if(this.waterColor != null)
                 player.Client.SendPacket(new SetWaterColorPacket(this.waterColor.Value));
+
+            if(this.waveHeight != 0)
+                this.server.BroadcastPacket(new SetWaveHeightPacket(this.waveHeight));
         }
 
         public void SetWeather(byte weather)
@@ -390,6 +394,18 @@ namespace SlipeServer.Server.Services
             this.waterLevel = waterLevel;
 
             this.server.BroadcastPacket(new SetWaterLevelPacket(waterLevel, includeWaterFeatures, includeWorldSea, includeOutsideWorldSea));
+        }
+
+        public void SetWaveHeight(float waveHeight)
+        {
+            this.waveHeight = Math.Clamp(waveHeight, 0, 100);
+
+            this.server.BroadcastPacket(new SetWaveHeightPacket(waveHeight));
+        }
+
+        public float GetWaveHeight()
+        {
+            return this.waveHeight;
         }
 
         public void SetTrafficLightState(TrafficLightState state, bool forced = false)

--- a/SlipeServer.Server/Services/GameWorld.cs
+++ b/SlipeServer.Server/Services/GameWorld.cs
@@ -1,4 +1,4 @@
-using SlipeServer.Packets.Definitions.Lua.Rpc.World;
+﻿using SlipeServer.Packets.Definitions.Lua.Rpc.World;
 using SlipeServer.Packets.Definitions.Sync;
 using SlipeServer.Server.Elements;
 using SlipeServer.Server.Enums;
@@ -26,6 +26,7 @@ namespace SlipeServer.Server.Services
         private Color? sunCoronaColor;
 
         private Color? waterColor;
+        private float waterLevel;
 
         private TrafficLightState trafficLightState;
         private bool trafficLightStateForced;
@@ -365,7 +366,6 @@ namespace SlipeServer.Server.Services
 
             this.server.BroadcastPacket(new SetSunColorPacket(core, corona));
         }
-
         public Tuple<Color, Color>? GetSunColor()
         {
             return (this.sunCoreColor != null && this.sunCoronaColor != null) ?
@@ -383,6 +383,13 @@ namespace SlipeServer.Server.Services
         public Color? GetWaterColor()
         {
             return this.waterColor;
+        }
+
+        public void SetWaterLevel(float waterLevel, bool includeWaterFeatures = true, bool includeWorldSea = true, bool includeOutsideWorldSea = false)
+        {
+            this.waterLevel = waterLevel;
+
+            this.server.BroadcastPacket(new SetWaterLevelPacket(waterLevel, includeWaterFeatures, includeWorldSea, includeOutsideWorldSea));
         }
 
         public void SetTrafficLightState(TrafficLightState state, bool forced = false)


### PR DESCRIPTION
Implements packets: SET_WORLD_WATER_LEVEL, SET_WATER_COLOR, SET_WAVE_HEIGHT
adds test commands: `watercolor`, `waterlevel <height>` , `wave <height>`