### PR TITLE
Feature/lua mapping

### DIFF
--- a/SlipeServer.Console/AdditionalResources/Parachute/ParachuteLogic.cs
+++ b/SlipeServer.Console/AdditionalResources/Parachute/ParachuteLogic.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using SlipeServer.Server;
 using SlipeServer.Server.Elements;
-using SlipeServer.Server.Elements.Structs;
 using SlipeServer.Server.Events;
 using SlipeServer.Server.Repositories;
 using SlipeServer.Server.Services;
@@ -34,7 +33,7 @@ public class ParachuteLogic
         this.resource = this.server.GetAdditionalResource<ParachuteResource>();
     }
 
-    private void HandlePlayerJoin(Server.Elements.Player player)
+    private void HandlePlayerJoin(Player player)
     {
         this.resource.StartFor(player);
     }
@@ -46,7 +45,7 @@ public class ParachuteLogic
         var otherPlayers = this.elementRepository
             .GetByType<Player>()
             .Except(new Player[] { luaEvent.Player });
-        this.luaEventService.TriggerEvent(otherPlayers, "doAddParachuteToPlayer", luaEvent.Player);
+        this.luaEventService.TriggerEventForMany(otherPlayers, "doAddParachuteToPlayer", luaEvent.Player);
     }
 
     public void HandleRequestRemoveParachute(LuaEvent luaEvent)
@@ -57,6 +56,6 @@ public class ParachuteLogic
         var otherPlayers = this.elementRepository
             .GetByType<Player>()
             .Except(new Player[] { luaEvent.Player });
-        this.luaEventService.TriggerEvent(otherPlayers, "doAddParachuteToPlayer", luaEvent.Player);
+        this.luaEventService.TriggerEventForMany(otherPlayers, "doAddParachuteToPlayer", luaEvent.Player);
     }
 }

--- a/SlipeServer.Console/Logic/LuaEventTestLogic.cs
+++ b/SlipeServer.Console/Logic/LuaEventTestLogic.cs
@@ -7,7 +7,7 @@ using System.Numerics;
 
 namespace SlipeServer.Console.Logic;
 
-struct DataStruct
+internal struct DataStruct
 {
     public string Foo { get; set; } = "Foo";
     public int Bar { get; set; } = 1;
@@ -18,7 +18,7 @@ struct DataStruct
     }
 }
 
-struct LuaMappableStruct : ILuaMappable
+internal struct LuaMappableStruct : ILuaMappable
 {
     public LuaValue ToLuaValue()
     {
@@ -26,26 +26,23 @@ struct LuaMappableStruct : ILuaMappable
     }
 }
 
-struct ExplicitStruct
+internal struct ExplicitStruct
 {
 
 }
 
 public class LuaEventTestLogic
 {
-    private readonly ILogger logger;
     private readonly LuaEventService luaEventService;
 
     public LuaEventTestLogic(
-        ILogger logger,
         CommandService commandService,
         LuaEventService luaEventService,
         LuaValueMapper mapper)
     {
-        this.logger = logger;
         this.luaEventService = luaEventService;
 
-        mapper.DefineMapper<ExplicitStruct>(x => new LuaValue("Explicit!"));
+        mapper.DefineStructMapper<ExplicitStruct>(x => new LuaValue("Explicit!"));
 
         commandService.AddCommand("sendvector").Triggered += SendLuaVector;
         commandService.AddCommand("sendvectorlist").Triggered += SendLuaVectorList;

--- a/SlipeServer.Console/Logic/LuaEventTestLogic.cs
+++ b/SlipeServer.Console/Logic/LuaEventTestLogic.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.Extensions.Logging;
+using SlipeServer.Packets.Definitions.Lua;
+using SlipeServer.Server.Events;
+using SlipeServer.Server.Mappers;
+using SlipeServer.Server.Services;
+using System.Numerics;
+
+namespace SlipeServer.Console.Logic;
+
+struct DataStruct
+{
+    public string Foo { get; set; } = "Foo";
+    public int Bar { get; set; } = 1;
+
+    public DataStruct()
+    {
+
+    }
+}
+
+struct LuaMappableStruct : ILuaMappable
+{
+    public LuaValue ToLuaValue()
+    {
+        return new LuaValue("Lua mapped!");
+    }
+}
+
+struct ExplicitStruct
+{
+
+}
+
+public class LuaEventTestLogic
+{
+    private readonly ILogger logger;
+    private readonly LuaEventService luaEventService;
+
+    public LuaEventTestLogic(
+        ILogger logger,
+        CommandService commandService,
+        LuaEventService luaEventService,
+        LuaValueMapper mapper)
+    {
+        this.logger = logger;
+        this.luaEventService = luaEventService;
+
+        mapper.DefineMapper<ExplicitStruct>(x => new LuaValue("Explicit!"));
+
+        commandService.AddCommand("sendvector").Triggered += SendLuaVector;
+        commandService.AddCommand("sendvectorlist").Triggered += SendLuaVectorList;
+        commandService.AddCommand("senddata").Triggered += SendDataStruct;
+        commandService.AddCommand("sendmapped").Triggered += SendLuaMappable;
+        commandService.AddCommand("sendexplicit").Triggered += SendExplicitStruct;
+    }
+
+    private void SendLuaVector(object? sender, CommandTriggeredEventArgs e)
+    {
+        this.luaEventService.TriggerEventFor(
+            e.Player,
+            "Slipe.Test.ClientEvent",
+            e.Player,
+            new Vector3(0, 1, 2));
+    }
+
+    private void SendLuaVectorList(object? sender, CommandTriggeredEventArgs e)
+    {
+        this.luaEventService.TriggerEventFor(
+            e.Player,
+            "Slipe.Test.ClientEvent",
+            e.Player,
+            new Vector3[]
+            {
+                e.Player.Position,
+                e.Player.Rotation,
+                e.Player.Forward,
+                e.Player.Right,
+                e.Player.Up
+            });
+    }
+
+    private void SendLuaMappable(object? sender, CommandTriggeredEventArgs e)
+    {
+        this.luaEventService.TriggerEventFor(
+            e.Player,
+            "Slipe.Test.ClientEvent",
+            e.Player,
+            new LuaMappableStruct());
+    }
+
+    private void SendDataStruct(object? sender, CommandTriggeredEventArgs e)
+    {
+        this.luaEventService.TriggerEventFor(
+            e.Player,
+            "Slipe.Test.ClientEvent",
+            e.Player,
+            new DataStruct());
+    }
+
+    private void SendExplicitStruct(object? sender, CommandTriggeredEventArgs e)
+    {
+        this.luaEventService.TriggerEventFor(
+            e.Player,
+            "Slipe.Test.ClientEvent",
+            e.Player,
+            new ExplicitStruct());
+    }
+}

--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -1032,9 +1032,9 @@ public class ServerTestLogic
             {
                 player.HasJetpack = !player.HasJetpack;
                 if(player.HasJetpack)
-                    this.logger.LogInformation($"{sender.Name} put on a jetpack!");
+                    this.logger.LogInformation("{name} put on a jetpack!", sender.Name);
                 else
-                    this.logger.LogInformation($"{sender.Name} pulled off his jetpack!");
+                    this.logger.LogInformation("{name} pulled off his jetpack!", sender.Name);
             }
             else if(e.Key == "h")
             {
@@ -1116,6 +1116,6 @@ public class ServerTestLogic
         });
         table.TableValue?.Add("self", table);
 
-        this.luaService.TriggerEvent(player, "Slipe.Test.ClientEvent", this.root, "String value", true, 23, table);
+        this.luaService.TriggerEventFor(player, "Slipe.Test.ClientEvent", this.root, "String value", true, 23, table);
     }
 }

--- a/SlipeServer.Console/Program.cs
+++ b/SlipeServer.Console/Program.cs
@@ -83,6 +83,7 @@ public partial class Program
                 builder.AddLogic<PhysicsTestLogic>();
                 builder.AddLogic<ElementPoolingTestLogic>();
                 builder.AddLogic<WarpIntoVehicleLogic>();
+                builder.AddLogic<LuaEventTestLogic>();
                 //builder.AddBehaviour<VelocityBehaviour>();
             }
         )

--- a/SlipeServer.Packets/Builder/LuaBuilderExtensions.cs
+++ b/SlipeServer.Packets/Builder/LuaBuilderExtensions.cs
@@ -97,16 +97,16 @@ public static class LuaBuilderExtensions
         {
             builder.Write(false);
             builder.WriteCompressed(value.IntegerValue.Value);
-        } else if (value.FloatValue.HasValue)
+        } else if (value.FloatValue.HasValue && value.FloatValue.Value != 0)
         {
             builder.Write(true);
             builder.Write(false);
             builder.Write(value.FloatValue.Value);
-        } else if (value.DoubleValue.HasValue)
+        } else if (value.DoubleValue.HasValue || value.FloatValue == 0)
         {
             builder.Write(true);
             builder.Write(true);
-            builder.Write(value.DoubleValue.Value);
+            builder.Write((value.DoubleValue ?? value.FloatValue)!.Value);
         }
     }
 

--- a/SlipeServer.Server/Behaviour/LocalServerAnnouncementBehaviour.cs
+++ b/SlipeServer.Server/Behaviour/LocalServerAnnouncementBehaviour.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using SlipeServer.Server.AllSeeingEye;
 using SlipeServer.Server.Constants;
 using System;
 using System.Net;

--- a/SlipeServer.Server/Behaviour/LocalServerAnnouncementBehaviour.cs
+++ b/SlipeServer.Server/Behaviour/LocalServerAnnouncementBehaviour.cs
@@ -49,11 +49,11 @@ public class LocalServerAnnouncementBehaviour
 
     private void StartListening(ushort port)
     {
-        IPHostEntry ipHostInfo = Dns.GetHostEntry(Dns.GetHostName());
-        IPAddress ipAddress = ipHostInfo.AddressList[0];
-        IPEndPoint localEndPoint = new IPEndPoint(ipAddress, port);
+        IPEndPoint localEndPoint = new IPEndPoint(IPAddress.Any, port);
 
-        UdpClient socket = new UdpClient(port);
+        UdpClient socket = new UdpClient();
+        socket.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+        socket.Client.Bind(localEndPoint);
         socket.BeginReceive(new AsyncCallback(OnUdpData), socket);
     }
 

--- a/SlipeServer.Server/Behaviour/LocalServerAnnouncementBehaviour.cs
+++ b/SlipeServer.Server/Behaviour/LocalServerAnnouncementBehaviour.cs
@@ -33,7 +33,7 @@ public class LocalServerAnnouncementBehaviour
                 IPEndPoint? source = new IPEndPoint(0, 0);
                 byte[] incomingData = socket.EndReceive(result, ref source);
                 string message = Encoding.UTF8.GetString(incomingData);
-                this.logger.LogInformation($"Local server broadcast received from {source?.Address} \"{message}\"");
+                this.logger.LogInformation("Local server broadcast received from {address} \"{message}\"", source?.Address, message);
 
                 byte[] data = Encoding.UTF8.GetBytes($"MTA-SERVER {this.configuration.Port + 123}");
 
@@ -42,7 +42,7 @@ public class LocalServerAnnouncementBehaviour
             }
             catch (Exception e)
             {
-                this.logger.LogError(e.Message);
+                this.logger.LogError("{exceptionMessage}", e.Message);
             }
         }
     }

--- a/SlipeServer.Server/Mappers/ILuaMappable.cs
+++ b/SlipeServer.Server/Mappers/ILuaMappable.cs
@@ -1,0 +1,7 @@
+﻿using SlipeServer.Packets.Definitions.Lua;
+
+namespace SlipeServer.Server.Mappers;
+public interface ILuaMappable
+{
+    LuaValue ToLuaValue();
+}

--- a/SlipeServer.Server/Mappers/LuaMapperBuilderExtensions.cs
+++ b/SlipeServer.Server/Mappers/LuaMapperBuilderExtensions.cs
@@ -1,0 +1,59 @@
+﻿using SlipeServer.Packets.Definitions.Lua;
+using SlipeServer.Server.ServerBuilders;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace SlipeServer.Server.Mappers;
+public static class LuaMapperBuilderExtensions
+{
+    public static void AddLuaMapping<T>(this ServerBuilder builder, Func<T, LuaValue> mapper) where T: class
+    {
+        builder.AddBuildStep((x) =>
+        {
+            x.GetRequiredService<LuaValueMapper>().DefineMapper<T>(mapper);
+        }, ServerBuildStepPriority.Low);
+    }
+    public static void AddStructLuaMapping<T>(this ServerBuilder builder, Func<T, LuaValue> mapper) where T: struct
+    {
+        builder.AddBuildStep((x) =>
+        {
+            x.GetRequiredService<LuaValueMapper>().DefineStructMapper<T>(mapper);
+        }, ServerBuildStepPriority.Low);
+    }
+
+    public static void AddLuaMapping(this ServerBuilder builder, Type type, Func<object, LuaValue> mapper)
+    {
+        builder.AddBuildStep((x) =>
+        {
+            x.GetRequiredService<LuaValueMapper>().DefineMapper(type, mapper);
+        }, ServerBuildStepPriority.Low);
+    }
+
+    public static void AddVectorMappings(this ServerBuilder builder)
+    {
+        builder.AddStructLuaMapping<Vector2>(x => new Dictionary<LuaValue, LuaValue>()
+        {
+            ["X"] = x.X,
+            ["Y"] = x.Y,
+        });
+        builder.AddStructLuaMapping<Vector3>(x => new Dictionary<LuaValue, LuaValue>()
+        {
+            ["X"] = x.X,
+            ["Y"] = x.Y,
+            ["Z"] = x.Z,
+        });
+        builder.AddStructLuaMapping<Vector4>(x => new Dictionary<LuaValue, LuaValue>()
+        {
+            ["X"] = x.X,
+            ["Y"] = x.Y,
+            ["Z"] = x.Z,
+            ["W"] = x.W,
+        });
+    }
+
+    public static void AddDefaultLuaMappings(this ServerBuilder builder)
+    {
+        builder.AddVectorMappings();
+    }
+}

--- a/SlipeServer.Server/Mappers/LuaValueMapper.cs
+++ b/SlipeServer.Server/Mappers/LuaValueMapper.cs
@@ -1,0 +1,126 @@
+﻿using SlipeServer.Packets.Definitions.Lua;
+using SlipeServer.Server.Elements;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace SlipeServer.Server.Mappers;
+public class LuaValueMapper
+{
+    private readonly Dictionary<Type, Func<object, LuaValue>> strictlyDefinedMappers;
+
+    public LuaValueMapper()
+    {
+        this.strictlyDefinedMappers = new();
+    }
+
+    public void DefineMapper(Type type, Func<object, LuaValue> mapper)
+    {
+        this.strictlyDefinedMappers[type] = mapper;
+    }
+
+    public void DefineMapper<T>(Func<object, LuaValue> mapper)
+    {
+        this.strictlyDefinedMappers[typeof(T)] = mapper;
+    }
+
+    public LuaValue Map(object? value)
+    {
+        if (value == null)
+            return new LuaValue();
+
+        if (this.strictlyDefinedMappers.TryGetValue(value.GetType(), out var mapper))
+            return mapper.Invoke(value);
+
+        if (value is ILuaMappable luaMappable)
+            return Map(luaMappable);
+
+        switch (value)
+        {
+            case int int32:
+                return int32;
+            case uint uint32:
+                return uint32;
+            case float single:
+                return single;
+            case double doublefloat:
+                return doublefloat;
+            case bool boolean:
+                return boolean;
+            case string text:
+                return text;
+            case Element element:
+                return Map(element);
+            case SByte:
+            case byte:
+            case short:
+            case ushort:
+                return (int)value;
+            case ulong:
+            case long:
+                throw new NotSupportedException($"Type {value.GetType()} not supported for Lua mapping");
+        }
+
+        if (value is IEnumerable<object> genericEnumerable)
+            return Map(genericEnumerable);
+
+        if (value is IEnumerable enumerable)
+            return Map(enumerable);
+
+        return MapBasedOnReflection(value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public LuaValue Map(Element element)
+    {
+        return new LuaValue(element.Id);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public LuaValue Map(ILuaMappable value)
+    {
+        return value.ToLuaValue();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public LuaValue Map(IEnumerable<object> values)
+    {
+        return new LuaValue(values.Select(x => Map(x)));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public LuaValue Map(IEnumerable values)
+    {
+        var luaValues = new List<LuaValue>();
+        foreach (var value in values)
+            luaValues.Add(Map(value));
+
+        return new LuaValue(luaValues);
+    }
+
+    private LuaValue MapBasedOnReflection(object value)
+    {
+        var dictionary = new Dictionary<LuaValue, LuaValue>();
+
+        var type = value.GetType();
+
+        var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+        foreach (var property in properties)
+        {
+            var propertyValue = property.GetValue(value);
+            dictionary[property.Name] = propertyValue == null ? new LuaValue() : Map(propertyValue);
+        }
+
+        var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public);
+        foreach (var field in fields)
+        {
+            var fieldValue = field.GetValue(value);
+            dictionary[field.Name] = fieldValue == null ? new LuaValue() : Map(fieldValue);
+        }
+
+        return new LuaValue(dictionary);
+    }
+}

--- a/SlipeServer.Server/MtaServer.cs
+++ b/SlipeServer.Server/MtaServer.cs
@@ -11,6 +11,7 @@ using SlipeServer.Server.Enums;
 using SlipeServer.Server.Events;
 using SlipeServer.Server.Extensions;
 using SlipeServer.Server.Loggers;
+using SlipeServer.Server.Mappers;
 using SlipeServer.Server.PacketHandling;
 using SlipeServer.Server.PacketHandling.Handlers;
 using SlipeServer.Server.PacketHandling.Handlers.Middleware;
@@ -239,6 +240,7 @@ public class MtaServer
         this.serviceCollection.AddSingleton<ChatBox>();
         this.serviceCollection.AddSingleton<ClientConsole>();
         this.serviceCollection.AddSingleton<DebugLog>();
+        this.serviceCollection.AddSingleton<LuaValueMapper>();
         this.serviceCollection.AddSingleton<LuaEventService>();
         this.serviceCollection.AddSingleton<LatentPacketService>();
         this.serviceCollection.AddSingleton<ExplosionService>();

--- a/SlipeServer.Server/Repositories/RTreeElementRepository.cs
+++ b/SlipeServer.Server/Repositories/RTreeElementRepository.cs
@@ -128,7 +128,8 @@ public class RTreeElementRepository : IElementRepository
 
         var results = this.elements
             .Search(new Envelope(position.X - range, position.Y - range, position.X + range, position.Y + range))
-            .Select(x => x.Element);
+            .Select(x => x.Element)
+            .ToArray();
 
         this.slimLock.ExitReadLock();
 
@@ -146,10 +147,12 @@ public class RTreeElementRepository : IElementRepository
 
     private void ReInsertElement(Element element, ElementChangedEventArgs<Vector3> args)
     {
+        this.slimLock.EnterWriteLock();
         this.elements.Delete(this.elementRefs[element]);
 
         var elementRef = new RTreeRef(element);
         this.elements.Insert(elementRef);
         this.elementRefs[element] = elementRef;
+        this.slimLock.ExitWriteLock();
     }
 }

--- a/SlipeServer.Server/ServerOptions/DefaultServerBuilderExtensions.cs
+++ b/SlipeServer.Server/ServerOptions/DefaultServerBuilderExtensions.cs
@@ -36,6 +36,7 @@ using SlipeServer.Server.PacketHandling.Handlers.CustomData;
 using SlipeServer.Packets.Definitions.CustomElementData;
 using SlipeServer.Packets.Definitions.Resources;
 using SlipeServer.Server.Resources.Serving;
+using SlipeServer.Server.Mappers;
 
 namespace SlipeServer.Server.ServerBuilders;
 
@@ -247,6 +248,7 @@ public static class DefaultServerBuilderExtensions
         builder.AddDefaultPacketHandler(exceptPacketHandlers);
         builder.AddDefaultBehaviours(exceptBehaviours);
         builder.AddDefaultServices(exceptServices, exceptMiddleware);
+        builder.AddDefaultLuaMappings();
 
         builder.AddResourceServer<BasicHttpServer>();
 

--- a/SlipeServer.Server/ServerOptions/ServerBuilder.cs
+++ b/SlipeServer.Server/ServerOptions/ServerBuilder.cs
@@ -59,7 +59,7 @@ public class ServerBuilder
     public void AddResourceServer<TResourceServer>(params object[] parameters)
         where TResourceServer : IResourceServer
     {
-        AddBuildStep(server => server.AddResourceServer(server.Instantiate<TResourceServer>()));
+        AddBuildStep(server => server.AddResourceServer(server.Instantiate<TResourceServer>(parameters)));
     }
 
     public void Instantiate<T>(params object[] parameters)

--- a/SlipeServer.Server/Services/LuaEventService.cs
+++ b/SlipeServer.Server/Services/LuaEventService.cs
@@ -3,10 +3,12 @@ using SlipeServer.Packets.Lua.Event;
 using SlipeServer.Server.Elements;
 using SlipeServer.Server.Events;
 using SlipeServer.Server.Extensions;
+using SlipeServer.Server.Mappers;
 using SlipeServer.Server.Repositories;
 using SlipeServer.Server.Resources;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SlipeServer.Server.Services;
 
@@ -16,17 +18,20 @@ public class LuaEventService
     private readonly RootElement root;
     private readonly LatentPacketService latentPacketService;
     private readonly IElementRepository elementRepository;
+    private readonly LuaValueMapper mapper;
     private readonly Dictionary<string, List<Action<LuaEvent>>> eventHandlers;
 
     public LuaEventService(MtaServer server,
         RootElement root,
         LatentPacketService latentPacketService,
-        IElementRepository elementRepository)
+        IElementRepository elementRepository,
+        LuaValueMapper mapper)
     {
         this.server = server;
         this.root = root;
         this.latentPacketService = latentPacketService;
         this.elementRepository = elementRepository;
+        this.mapper = mapper;
         this.eventHandlers = new Dictionary<string, List<Action<LuaEvent>>>();
 
         server.LuaEventTriggered += HandleLuaEvent;
@@ -37,32 +42,98 @@ public class LuaEventService
         this.server.BroadcastPacket(new LuaEventPacket(eventName, (source ?? this.root).Id, parameters));
     }
 
-    public void TriggerEvent(Player player, string eventName, Element? source = null, params LuaValue[] parameters)
+    public void TriggerEvent(string eventName, Element? source = null, params object[] parameters)
+    {
+        TriggerEvent(eventName, source, parameters.Select(x => this.mapper.Map(x)).ToArray());
+    }
+
+    public void TriggerEvent(string eventName, Element? source = null)
+    {
+        TriggerEvent(eventName, source, Array.Empty<LuaValue>());
+    }
+
+
+    public void TriggerEventFor(Player player, string eventName, Element? source = null, params LuaValue[] parameters)
     {
         new LuaEventPacket(eventName, (source ?? this.root).Id, parameters).SendTo(player);
     }
 
-    public void TriggerLatentEvent(IEnumerable<Player> players, string eventName, Resource sourceResource, Element? source = null, int rate = 50000, params LuaValue[] parameters)
+    public void TriggerEventFor(Player player, string eventName, Element? source = null, params object[] parameters)
     {
-        var packet = new LuaEventPacket(eventName, (source ?? this.root).Id, parameters);
-        this.latentPacketService.EnqueueLatentPacket(players, packet, sourceResource.NetId, rate);
+        TriggerEventFor(player, eventName, source, parameters.Select(x => this.mapper.Map(x)).ToArray());
     }
+
+    public void TriggerEventFor(Player player, string eventName, Element? source = null)
+    {
+        TriggerEventFor(player, eventName, source, Array.Empty<LuaValue>());
+    }
+
+
+    public void TriggerEventForMany(IEnumerable<Player> players, string eventName, Element? source = null, params LuaValue[] parameters)
+    {
+        new LuaEventPacket(eventName, (source ?? this.root).Id, parameters).SendTo(players);
+    }
+
+    public void TriggerEventForMany(IEnumerable<Player> players, string eventName, Element? source = null, params object[] parameters)
+    {
+        TriggerEventForMany(players, eventName, source, parameters.Select(x => this.mapper.Map(x)).ToArray());
+    }
+
+    public void TriggerEventForMany(IEnumerable<Player> players, string eventName, Element? source = null)
+    {
+        TriggerEventForMany(players, eventName, source, Array.Empty<LuaValue>());
+    }
+
 
     public void TriggerLatentEvent(string eventName, Resource sourceResource, Element? source = null, int rate = 50000, params LuaValue[] parameters)
     {
-        TriggerLatentEvent(this.elementRepository.GetByType<Player>(ElementType.Player), eventName, sourceResource, source, rate, parameters);
+        TriggerLatentEventForMany(this.elementRepository.GetByType<Player>(ElementType.Player), eventName, sourceResource, source, rate, parameters);
     }
 
-    public void TriggerLatentEvent(Player player, string eventName, Resource sourceResource, Element? source = null, int rate = 50000, params LuaValue[] parameters)
+    public void TriggerLatentEvent(string eventName, Resource sourceResource, Element? source = null, int rate = 50000, params object[] parameters)
+    {
+        TriggerLatentEvent(eventName, sourceResource, source, rate, parameters.Select(x => this.mapper.Map(x)).ToArray());
+    }
+
+    public void TriggerLatentEvent(string eventName, Resource sourceResource, Element? source = null, int rate = 50000)
+    {
+        TriggerLatentEvent(eventName, sourceResource, source, rate, Array.Empty<LuaValue>());
+    }
+
+
+    public void TriggerLatentEventFor(Player player, string eventName, Resource sourceResource, Element? source = null, int rate = 50000, params LuaValue[] parameters)
     {
         var packet = new LuaEventPacket(eventName, (source ?? this.root).Id, parameters);
         this.latentPacketService.EnqueueLatentPacket(new Player[] { player }, packet, sourceResource.NetId, rate);
     }
 
-    public void TriggerEvent(IEnumerable<Player> players, string eventName, Element? source = null, params LuaValue[] parameters)
+    public void TriggerLatentEventFor(Player player, string eventName, Resource sourceResource, Element? source = null, int rate = 50000, params object[] parameters)
     {
-        new LuaEventPacket(eventName, (source ?? this.root).Id, parameters).SendTo(players);
+        TriggerLatentEventFor(player, eventName, sourceResource, source, rate, parameters.Select(x => this.mapper.Map(x)).ToArray());
     }
+
+    public void TriggerLatentEventFor(Player player, string eventName, Resource sourceResource, Element? source = null, int rate = 50000)
+    {
+        TriggerLatentEventFor(player, eventName, sourceResource, source, rate, Array.Empty<LuaValue>());
+    }
+
+
+    public void TriggerLatentEventForMany(IEnumerable<Player> players, string eventName, Resource sourceResource, Element? source = null, int rate = 50000, params LuaValue[] parameters)
+    {
+        var packet = new LuaEventPacket(eventName, (source ?? this.root).Id, parameters);
+        this.latentPacketService.EnqueueLatentPacket(players, packet, sourceResource.NetId, rate);
+    }
+
+    public void TriggerLatentEventForMany(IEnumerable<Player> players, string eventName, Resource sourceResource, Element? source = null, int rate = 50000, params object[] parameters)
+    {
+        TriggerLatentEventForMany(players, eventName, sourceResource, source, rate, parameters.Select(x => this.mapper.Map(x)).ToArray());
+    }
+
+    public void TriggerLatentEventForMany(IEnumerable<Player> players, string eventName, Resource sourceResource, Element? source = null, int rate = 50000)
+    {
+        TriggerLatentEventForMany(players, eventName, sourceResource, source, rate, Array.Empty<LuaValue>());
+    }
+
 
     public void AddEventHandler(string eventName, Action<LuaEvent> handler)
     {


### PR DESCRIPTION
- Adds a `LuaValueMapper` to map C# objects to `LuaValue`
- Adds overloads for `LuaEventService` to use this `LuaValueMapper`
- Renames methods in `LuaEventService` to prevent ambiguous references (potential breaking change)
- Fixes a bug that resulted in numeric `0` being sent as LuaValue to be received as `-nan(ind)`


The `LuaValueMapper` maps objects in one of several ways:
- Through implementation of the `ILuaMappable` interface
- Through explicitly defined implementations on the `LuaValueMapper`. Which can be defined using `serverBuilder.AddLuaMapping`
- Through "known" types (elements, numeric types, booleans, strings)
- Through reflection