### PR TITLE
Add LuaValue Nil static property

### DIFF
--- a/SlipeServer.Packets/Definitions/Lua/LuaValue.cs
+++ b/SlipeServer.Packets/Definitions/Lua/LuaValue.cs
@@ -20,6 +20,11 @@ public class LuaValue
     public bool IsNil { get; }
 
 
+    private static readonly LuaValue nil = new LuaValue
+    {
+        LuaType = LuaType.Nil
+    };
+
     public LuaValue()
     {
         this.IsNil = true;
@@ -181,4 +186,6 @@ public class LuaValue
         var stringKeyedDictionary = value.TableValue.ToDictionary(x => x.Key.StringValue!, x => x.Value);
         return new ((float)stringKeyedDictionary["X"], (float)stringKeyedDictionary["Y"], (float)stringKeyedDictionary["Z"]);
     }
+
+    public static LuaValue Nil => nil;
 }

--- a/SlipeServer.Packets/Definitions/Lua/LuaValue.cs
+++ b/SlipeServer.Packets/Definitions/Lua/LuaValue.cs
@@ -18,12 +18,7 @@ public class LuaValue
     public uint? ElementId { get; }
     public Dictionary<LuaValue, LuaValue>? TableValue { get; }
     public bool IsNil { get; }
-
-
-    private static readonly LuaValue nil = new LuaValue
-    {
-        LuaType = LuaType.Nil
-    };
+    public static LuaValue Nil { get; } = new LuaValue();
 
     public LuaValue()
     {
@@ -186,6 +181,4 @@ public class LuaValue
         var stringKeyedDictionary = value.TableValue.ToDictionary(x => x.Key.StringValue!, x => x.Value);
         return new ((float)stringKeyedDictionary["X"], (float)stringKeyedDictionary["Y"], (float)stringKeyedDictionary["Z"]);
     }
-
-    public static LuaValue Nil => nil;
 }


### PR DESCRIPTION
reason: `LuaValue.Nil` is more explicit and convinient than `new LuaValue()` or `new LuaValue{  LuaType = LuaType.Nil }`
and: no unneccessary allocations :)