### PR TITLE
Fix collision shape detection

### DIFF
--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -1360,6 +1360,62 @@ public class ServerTestLogic
             [3] = true,
             [4] = true,
         });
+
+        this.commandService.AddCommand("collisionshapetest").Triggered += async (source, args) =>
+        {
+            var p1 = args.Player.Position + new Vector3(8, 0, 0);
+            var p2 = args.Player.Position + new Vector3(-8, 0, 0);
+            var col1 = new CollisionSphere(p1, 3).AssociateWith(this.server);
+            var col2 = new CollisionSphere(p2, 3).AssociateWith(this.server);
+            int insideRefCounter = 0;
+            col1.ElementEntered += e =>
+            {
+                if (e is Player)
+                {
+                    insideRefCounter++;
+                    this.chatBox.Output($"Entered 1, counter: {insideRefCounter}");
+                }
+            };
+            col2.ElementEntered += e =>
+            {
+                if (e is Player)
+                {
+                    insideRefCounter++;
+                    this.chatBox.Output($"Entered 2, counter: {insideRefCounter}");
+                }
+            };
+            col1.ElementLeft += e =>
+            {
+                if (e is Player)
+                {
+                    insideRefCounter--;
+                    this.chatBox.Output($"Left 1, counter: {insideRefCounter}");
+                }
+            };
+            col2.ElementLeft += e =>
+            {
+                if (e is Player)
+                {
+                    insideRefCounter--;
+                    this.chatBox.Output($"Left 2, counter: {insideRefCounter}");
+                }
+            };
+
+            int counter = 20;
+            while (true)
+            {
+                if (counter-- % 2 == 0)
+                {
+                    args.Player.Position = p1;
+                } else
+                {
+                    args.Player.Position = p2;
+                }
+                await Task.Delay(500);
+                if (counter == 0)
+                    break;
+            }
+        };
     }
 
     private void OnPlayerJoin(CustomPlayer player)

--- a/SlipeServer.Server/Behaviour/CollisionShapeBehaviour.cs
+++ b/SlipeServer.Server/Behaviour/CollisionShapeBehaviour.cs
@@ -49,7 +49,12 @@ public class CollisionShapeBehaviour
     {
         foreach (var shape in this.collisionShapes)
         {
-            shape.Key.CheckElementWithin(element);
+            shape.Key.CheckElementLeft(element);
+        }
+
+        foreach (var shape in this.collisionShapes)
+        {
+            shape.Key.CheckElementEntered(element);
         }
     }
 

--- a/SlipeServer.Server/Elements/ColShapes/CollisionShape.cs
+++ b/SlipeServer.Server/Elements/ColShapes/CollisionShape.cs
@@ -29,6 +29,30 @@ public abstract class CollisionShape : Element
 
     public bool IsWithin(Element element) => IsWithin(element.Position);
 
+    public bool CheckElementEntered(Element element)
+    {
+        if (!this.elementsWithin.ContainsKey(element) && IsWithin(element))
+        {
+            this.elementsWithin[element] = 0;
+            this.ElementEntered?.Invoke(element);
+            element.Destroyed += OnElementDestroyed;
+            return true;
+        }
+        return false;
+    }
+
+    public bool CheckElementLeft(Element element)
+    {
+        if (this.elementsWithin.ContainsKey(element) && !IsWithin(element))
+        {
+            this.elementsWithin.Remove(element, out var _);
+            this.ElementLeft?.Invoke(element);
+            element.Destroyed -= OnElementDestroyed;
+            return true;
+        }
+        return false;
+    }
+    
     public void CheckElementWithin(Element element)
     {
         if (IsWithin(element))


### PR DESCRIPTION
Fixes order of enter/left events trigger while  teleporting between two collision shapes.
Previously it was possible to be in two different collision shapes that are not intersect with each other.
