### PR TITLE
Fix vehicle entering

### DIFF
--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -903,6 +903,46 @@ public class ServerTestLogic
             this.server.BroadcastPacket(PickupPacketFactory.CreateDestroyAllPacket());
         };
 
+        this.commandService.AddCommand("addmyvehevent").Triggered += (source, args) =>
+        {
+            args.Player.VehicleChanged += (sender, args) =>
+            {
+                this.chatBox.Output($"vehicle changed {args.NewValue}");
+            };
+            args.Player.EnteringVehicleChanged += (sender, args) =>
+            {
+                this.chatBox.Output($"entering vehicle changed {args.NewValue}");
+            };
+            args.Player.JackingVehicleChanged += (sender, args) =>
+            {
+                this.chatBox.Output($"jacking vehicle changed {args.NewValue}");
+            };
+            args.Player.VehicleActionChanged += (sender, args) =>
+            {
+                this.chatBox.Output($"VehicleActionChanged {args.NewValue}");
+
+            };
+        };
+        this.commandService.AddCommand("destroymyveh").Triggered += (source, args) =>
+        {
+            if (args.Player.Vehicle != null)
+            {
+                args.Player.Vehicle.Destroy();
+                this.chatBox.Output($"destroyed... veh={args.Player.Vehicle} {args.Player.Vehicle.IsDestroyed}");
+            }
+        };
+        this.commandService.AddCommand("destroyenteredvehicle").Triggered += (source, args) =>
+        {
+            if (args.Player.EnteringVehicle != null)
+            {
+                args.Player.EnteringVehicle.Destroy();
+                this.chatBox.Output($"destroyed EnteringVehicle");
+            }
+        };
+        this.commandService.AddCommand("myveh").Triggered += (source, args) =>
+        {
+            this.chatBox.Output($"your veh: Vehicle={args.Player.Vehicle != null} EnteringVehicle={args.Player.EnteringVehicle != null} VehicleAction={args.Player.VehicleAction}");
+        };
         this.commandService.AddCommand("slipelua").Triggered += async (source, args) =>
         {
             var stopwatch = new Stopwatch();

--- a/SlipeServer.Server/Elements/Player.cs
+++ b/SlipeServer.Server/Elements/Player.cs
@@ -191,6 +191,7 @@ public class Player : Ped
     {
         if (this.Vehicle != null)
             this.Vehicle.RunAsSync(() => this.Vehicle.RemovePassenger(this));
+        EnteringVehicle = null;
     }
 
     public new Player AssociateWith(MtaServer server)
@@ -230,10 +231,7 @@ public class Player : Ped
         this.dimension = dimension;
 
         this.Weapons.Clear(false);
-        this.Vehicle = null;
-        this.Seat = null;
-        this.VehicleAction = VehicleAction.None;
-        this.HasJetpack = false;
+        this.Reset();
         this.health = 100;
         this.armor = 0;
 
@@ -285,10 +283,7 @@ public class Player : Ped
     {
         this.RunAsSync(() =>
         {
-            this.health = 0;
-            this.Vehicle = null;
-            this.Seat = null;
-            this.VehicleAction = VehicleAction.None;
+            Reset();
             InvokeWasted(new PedWastedEventArgs(this, damager, damageType, bodyPart, animationGroup, animationId));
         });
     }

--- a/SlipeServer.Server/Elements/Vehicle.cs
+++ b/SlipeServer.Server/Elements/Vehicle.cs
@@ -555,6 +555,7 @@ public class Vehicle : Element
         }
         this.Occupants[seat] = ped;
         ped.Vehicle = this;
+        ped.EnteringVehicle = null;
         ped.Seat = seat;
 
         this.PedEntered?.Invoke(this, new VehicleEnteredEventsArgs(ped, this, seat, warpsIn));
@@ -568,6 +569,7 @@ public class Vehicle : Element
 
             this.Occupants.Remove(item.Key);
             ped.Vehicle = null;
+            ped.EnteringVehicle = null;
 
             this.PedLeft?.Invoke(this, new VehicleLeftEventArgs(ped, this, item.Key, warpsOut));
         }

--- a/SlipeServer.Server/PacketHandling/Handlers/Vehicle/VehicleInOutPacketHandler.cs
+++ b/SlipeServer.Server/PacketHandling/Handlers/Vehicle/VehicleInOutPacketHandler.cs
@@ -136,7 +136,7 @@ public class VehicleInOutPacketHandler : IPacketHandler<VehicleInOutPacket>
                     vehicle.AddPassenger(packet.Seat, client.Player, true);
                 } else
                 {
-                    client.Player.Vehicle = vehicle;
+                    client.Player.EnteringVehicle = vehicle;
                     client.Player.VehicleAction = VehicleAction.Entering;
 
                     var replyPacket = new VehicleInOutPacket()
@@ -196,7 +196,7 @@ public class VehicleInOutPacketHandler : IPacketHandler<VehicleInOutPacket>
             }
 
             client.Player.Seat = packet.Seat;
-            client.Player.Vehicle = vehicle;
+            client.Player.EnteringVehicle = vehicle;
             client.Player.VehicleAction = VehicleAction.Entering;
 
             if (warpIn)
@@ -236,9 +236,10 @@ public class VehicleInOutPacketHandler : IPacketHandler<VehicleInOutPacket>
         if (client.Player.VehicleAction == VehicleAction.Entering)
         {
             client.Player.VehicleAction = VehicleAction.None;
-            if (client.Player.Vehicle != null)
+            if (client.Player.EnteringVehicle == vehicle)
             {
-                vehicle.IsEngineOn = true;
+                client.Player.Vehicle = client.Player.EnteringVehicle;
+                client.Player.EnteringVehicle = null;
                 vehicle.AddPassenger(client.Player.Seat ?? 0, client.Player, false);
 
                 var replyPacket = new VehicleInOutPacket()
@@ -258,6 +259,7 @@ public class VehicleInOutPacketHandler : IPacketHandler<VehicleInOutPacket>
         if (client.Player.VehicleAction == VehicleAction.Entering)
         {
             client.Player.VehicleAction = VehicleAction.None;
+            client.Player.EnteringVehicle = null;
             client.Player.Vehicle = null;
             vehicle.RemovePassenger(client.Player, false);
 
@@ -318,6 +320,7 @@ public class VehicleInOutPacketHandler : IPacketHandler<VehicleInOutPacket>
             return;
 
         client.Player.Vehicle = null;
+        client.Player.EnteringVehicle = null;
         client.Player.VehicleAction = VehicleAction.None;
 
         if (!vehicle.Occupants.ContainsValue(client.Player))
@@ -358,14 +361,13 @@ public class VehicleInOutPacketHandler : IPacketHandler<VehicleInOutPacket>
 
     private void HandleNotifyFellOff(IClient client, Elements.Vehicle vehicle, VehicleInOutPacket packet)
     {
-
         if (!vehicle.Occupants.ContainsValue(client.Player))
             return;
 
         client.Player.VehicleAction = VehicleAction.None;
         client.Player.Vehicle = null;
+        client.Player.EnteringVehicle = null;
         vehicle.RemovePassenger(client.Player, false);
-
 
         var replyPacket = new VehicleInOutPacket()
         {
@@ -393,6 +395,7 @@ public class VehicleInOutPacketHandler : IPacketHandler<VehicleInOutPacket>
             vehicle.JackingPed = null;
 
             client.Player.Vehicle = vehicle;
+            client.Player.EnteringVehicle = null;
             client.Player.VehicleAction = VehicleAction.None;
             vehicle.AddPassenger(0, client.Player, false);
 


### PR DESCRIPTION
Split "Vehicle" property into "Vehicle" - indicating your current vehicle you are controlling, and "EnteringVehicle" - a vehicle you are entering.
Fixes bug where when vehicle gets destroyed "Vehicle" wasn't reseted