### PR TITLE
Fix: Vehicle sync while joining to the server

### DIFF
--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -157,6 +157,30 @@ public class ServerTestLogic
         this.worldService.SetGlitchEnabled(GlitchType.GLITCH_FASTSPRINT, true);
 
         this.server.PlayerJoined += OnPlayerJoin;
+
+        Task.Run(async () =>
+        {
+            while (true)
+            {
+                foreach (var item in elementCollection.GetByType<Player>())
+                {
+                    if(item.Vehicle == null)
+                        item.SetData("currentVehicle", LuaValue.Nil, DataSyncType.Broadcast);
+                    else
+                        item.SetData("currentVehicle", item.Vehicle, DataSyncType.Broadcast);
+                }
+
+                foreach (var item in elementCollection.GetByType<Ped>())
+                {
+                    if (item.Vehicle == null)
+                        item.SetData("currentVehicle", LuaValue.Nil, DataSyncType.Broadcast);
+                    else
+                        item.SetData("currentVehicle", item.Vehicle, DataSyncType.Broadcast);
+                }
+
+                await Task.Delay(100);
+            }
+        });
     }
 
     private void SetupTestElements()
@@ -221,7 +245,7 @@ public class ServerTestLogic
 
         this.FrozenVehicle = new Vehicle(602, new Vector3(0, 0, 10)).AssociateWith(this.server);
         this.FrozenVehicle.IsFrozen = true;
-
+        this.Ped.WarpIntoVehicle(this.FrozenVehicle);
         this.PrivateVehicle = new Vehicle(602, new Vector3(-10.58f, -5.70f, 3.11f)).AssociateWith(this.server);
         this.PrivateVehicle.CanEnter = (Ped ped, Vehicle vehicle, byte seat) =>
         {
@@ -980,10 +1004,11 @@ public class ServerTestLogic
         };
         this.commandService.AddCommand("destroymyveh").Triggered += (source, args) =>
         {
-            if (args.Player.Vehicle != null)
+            var vehicle = args.Player.Vehicle;
+            if (vehicle != null)
             {
-                args.Player.Vehicle.Destroy();
-                this.chatBox.Output($"destroyed... veh={args.Player.Vehicle} {args.Player.Vehicle.IsDestroyed}");
+                vehicle.Destroy();
+                this.chatBox.Output($"Destroyed your vehicle. Veh={args.Player.Vehicle} Destroyed={vehicle.IsDestroyed}");
             }
         };
         this.commandService.AddCommand("destroyenteredvehicle").Triggered += (source, args) =>

--- a/SlipeServer.Console/Resources/TestResource/test.lua
+++ b/SlipeServer.Console/Resources/TestResource/test.lua
@@ -93,3 +93,25 @@ addCommandHandler("myvehprintdamageclient", function()
         end
     end
 end)
+
+local screenX, screenY = guiGetScreenSize()
+local color = tocolor(255,255,255)
+
+local function printDebugVehicle(k, ped)
+	local veh = getPedOccupiedVehicle(ped)
+	local name = (getElementType(ped) == "ped") and "ped" or getPlayerName(ped);
+
+	dxDrawText(string.format("%s - %s/%s", name, veh and tostring(veh) or "<none>", getElementData(ped, "currentVehicle") and tostring(getElementData(ped, "currentVehicle")) or "<none>"), screenX - 600, 400 + k * 25, screenX - 600, 400 + k * 25, color, 1.5, "sans")
+end
+
+addEventHandler("onClientRender", root, function()
+	local k = 0
+	for i,v in ipairs(getElementsByType("player"))do
+		k = k + 1
+		printDebugVehicle(k, v);
+	end
+	for i,v in ipairs(getElementsByType("ped"))do
+		k = k + 1
+		printDebugVehicle(k, v);
+	end
+end)

--- a/SlipeServer.Server/PacketHandling/Factories/AddEntityPacketFactory.cs
+++ b/SlipeServer.Server/PacketHandling/Factories/AddEntityPacketFactory.cs
@@ -4,6 +4,7 @@ using SlipeServer.Server.Elements;
 using SlipeServer.Server.Elements.ColShapes;
 using SlipeServer.Server.PacketHandling.Builders;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SlipeServer.Server.PacketHandling.Factories;
 
@@ -13,7 +14,7 @@ public static class AddEntityPacketFactory
     {
         var builder = new AddEntityPacketBuilder();
 
-        foreach (var element in elements)
+        foreach (var element in elements.OrderBy(x => x.ElementType))
         {
             if (element.Id == ElementId.Zero)
                 throw new System.Exception(string.Format("Element {0} can not be created with id 0", element.ElementType));


### PR DESCRIPTION
Elements to client are send in order by element type, see https://github.com/multitheftauto/mtasa-blue/blob/master/Server/mods/deathmatch/logic/CElement.cpp#L268

Also, added simple debug to see what see server and what sees client:

`player or ped - client/server`
![image](https://github.com/user-attachments/assets/651f8fb2-ccff-44ce-9aa0-578e035edd2d)
