### PR TITLE
Improve performance of noClientScripts

### DIFF
--- a/SlipeServer.Console/Logic/ServerTestLogic.cs
+++ b/SlipeServer.Console/Logic/ServerTestLogic.cs
@@ -186,9 +186,8 @@ public class ServerTestLogic
     {
         this.testResource = this.resourceProvider.GetResource("TestResource");
         this.secondTestResource = this.resourceProvider.GetResource("SecondTestResource");
-        this.secondTestResource.NoClientScripts[$"{this.secondTestResource!.Name}/testfile.lua"] =
-            Encoding.UTF8.GetBytes("outputChatBox(\"I AM A NOT CACHED MESSAGE\")");
-        this.secondTestResource.NoClientScripts[$"blabla.lua"] = new byte[] { };
+        this.secondTestResource.AddNoClientScript($"{this.secondTestResource!.Name}/testfile.lua", "outputChatBox(\"I AM A NOT CACHED MESSAGE\")");
+        this.secondTestResource.AddNoClientScript("blabla.lua", []);
 
         this.thirdTestResource = this.resourceProvider.GetResource("MetaXmlTestResource");
 

--- a/SlipeServer.Server.Tests/Integration/Interpreters/MetaXmlResourceInterpreterTests.cs
+++ b/SlipeServer.Server.Tests/Integration/Interpreters/MetaXmlResourceInterpreterTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Moq;
+using SlipeServer.Server.Resources;
 using SlipeServer.Server.Resources.Interpreters;
 using SlipeServer.Server.Resources.Providers;
 using SlipeServer.Server.TestTools;
@@ -50,7 +51,7 @@ public class MetaXmlResourceInterpreterTests
         resource.PriorityGroup.Should().Be(0);
         resource.NoClientScripts.Should().BeEquivalentTo(new Dictionary<string, byte[]>
         {
-            ["script.lua"] = "420"u8.ToArray(),
+            ["script.lua"] = Resource.CompressFile("420"u8.ToArray()),
         });
     }
 
@@ -95,7 +96,7 @@ public class MetaXmlResourceInterpreterTests
         resource.PriorityGroup.Should().Be(1234);
         resource.NoClientScripts.Should().BeEquivalentTo(new Dictionary<string, byte[]>
         {
-            ["script1.lua"] = "420"u8.ToArray(),
+            ["script1.lua"] = Resource.CompressFile([.. "420"u8]),
         });
     }
 }

--- a/SlipeServer.Server/Resources/Interpreters/MetaXmlResourceInterpreter.cs
+++ b/SlipeServer.Server/Resources/Interpreters/MetaXmlResourceInterpreter.cs
@@ -55,9 +55,12 @@ public class MetaXmlResourceInterpreter : IResourceInterpreter
             PriorityGroup = (meta.Value.downloadPriorityGroup != null && meta.Value.downloadPriorityGroup.Length > 0) ? meta.Value.downloadPriorityGroup.First().Data : 0,
             Files = GetFilesForMetaXmlResource(meta.Value, files),
             Exports = GetExportsForMetaXmlResource(meta.Value).ToList(),
-            NoClientScripts = GetNoCacheFiles(meta.Value, files),
             IsOopEnabled = meta.Value.oops != null && meta.Value.oops.Any(x => x.Data.ToLower() == "true")
         };
+
+        foreach (var item in GetNoCacheFiles(meta.Value, files))
+            resource.AddNoClientScript(item.Key, item.Value);
+
         return resource;
     }
 

--- a/SlipeServer.WebHostBuilderExample/SampleResource.cs
+++ b/SlipeServer.WebHostBuilderExample/SampleResource.cs
@@ -54,7 +54,7 @@ internal class SampleResource : Resource
 
     internal SampleResource(MtaServer server) : base(server, server.RootElement, "Sample")
     {
-        this.NoClientScripts["foo.lua"] = System.Text.UTF8Encoding.UTF8.GetBytes("outputChatBox('sample')");
+        this.AddNoClientScript("foo.lua", "outputChatBox('sample')");
 
         foreach (var (path, content) in AdditionalFiles)
             Files.Add(ResourceFileFactory.FromBytes(content, path));


### PR DESCRIPTION
| Method       | Mean     | Error   | StdDev  | Gen0    | Gen1    | Allocated |
|------------- |---------:|--------:|--------:|--------:|--------:|----------:|
| CompressTest | 134.9 us | 2.59 us | 3.45 us | 60.5469 | 30.0293 | 311.24 KB |

Don't compress file every time player join, 8KB cause 311KB of allocations, if you really want soruce code, just add your own dictionary with sources